### PR TITLE
fix: support for python3.11 dataclass mutability https://github.com/p…

### DIFF
--- a/src/http_logging/secondary_classes.py
+++ b/src/http_logging/secondary_classes.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from typing import Callable, Optional
 
@@ -41,7 +41,7 @@ class HttpSecurity:
     ssl_verify: bool = True
     keyfile: str = None
     certfile: str = None
-    ca_certs: list = None
+    ca_certs: list = field(default_factory=list)
 
 
 @dataclass
@@ -52,13 +52,13 @@ class ConfigLog:
     encoding: str = constants.ENCODING
     custom_headers: Callable = None
     enable: bool = True
-    security: HttpSecurity = HttpSecurity()
+    security: HttpSecurity = field(default_factory=HttpSecurity)
 
 
 @dataclass
 class SupportClass:
     http_host: HttpHost
-    config: ConfigLog = ConfigLog()
+    config: ConfigLog = field(default_factory=ConfigLog)
     _transport: Transport = None
     _formatter: logging.Formatter = None
 


### PR DESCRIPTION
In python 3.11

https://www.micahsmith.com/blog/2020/01/dataclasses-mutable-defaults/
https://github.com/python/cpython/issues/88840

```
➜  py-async-http-logging git:(Py3.11) ✗ python3 tests/unit/test_handler.py
Traceback (most recent call last):
  File "/home/brvier/Projects/py-async-http-logging/tests/unit/test_handler.py", line 3, in <module>
    import http_logging
  File "/home/brvier/.local/lib/python3.11/site-packages/http_logging/__init__.py", line 1, in <module>
    from .secondary_classes import (
  File "/home/brvier/.local/lib/python3.11/site-packages/http_logging/secondary_classes.py", line 47, in <module>
    @dataclass
     ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1220, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1210, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'http_logging.secondary_classes.HttpSecurity'> for field security is not allowed: use default_factory
```